### PR TITLE
blocking phpinfo

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,7 +2,7 @@ RewriteEngine on
 RewriteCond $1 !^(index\.php|js|css|images|img|files|phpinfo\.php|robots\.txt)
 RewriteRule ^(.*)$ /~tophtucker/bonus/index.php/$1 [L]
 
-<Files php-info.php>
+<Files phpinfo.php>
        Order Deny,Allow
        Deny from all
        Allow from 139.140.0.0/16


### PR DESCRIPTION
on the "brian is paranoid" front:

Our phpinfo is available to anyone who wants to read it, which is bad - it could potentially reveal to an attacker that we're running an unpatched version of Apache (yup, we are) or reveal our document root or database location. I added a exclusion clause to the root .htaccess to keep anyone off campus from seeing it, because it's just useful enough that we wouldn't want to delete it entirely.
