### PR TITLE
Opacity

### DIFF
--- a/css/orient.css
+++ b/css/orient.css
@@ -1072,7 +1072,7 @@ section h2, #sidebar h2 {
 }
 
 .old {
-	opacity: 0.3;
+	opacity: 1;
 }
 
 .old:hover {


### PR DESCRIPTION
Disables greying-out of .old blocks until we go back into production in the fall again. 
