### PR TITLE
(Sub)Title length limits

### DIFF
--- a/application/views/article.php
+++ b/application/views/article.php
@@ -349,16 +349,23 @@
     // if only i really knew javascript
     // #dry :(
 
-    $('#articletitle').keyup(function() {
+    $('#articletitle').keydown(function() {
     	titleedited=true;
     	$('#articletitle').css("color", "darkred");
-    	document.title = $('#articletitle').html() + " — The Bowdoin Orient";
     	$('#title.charsremaining').html(200 - $('#articletitle').html().length);
-    	if((200 - $('#articletitle').html().length) < 25){
-    		$('#title.charsremaining').css("color", "#E3170D");
+    	if ($('#articletitle').html().length>200) {
+    		$("button#savearticle").attr("disabled", "disabled");
+    		$("#articletitle").addClass("toolongwarning");
+    	} else if((200 - $('#articletitle').html().length) < 25) {
+    		$("#articletitle").removeClass("toolongwarning");
+    		$("button#savearticle").removeAttr("disabled");
+    		$('#title.charsremaining').addClass("lowchars");
     	} else {
-    		$('#title.charsremaining').css("color", "green");
+    		$('#title.charsremaining').removeClass("lowchars");
     	}
+    });
+    $('#articletitle').keyup(function() {
+    	document.title = $('#articletitle').html() + " — The Bowdoin Orient";
     });
     $("#articletitle").bind('paste', function() {
     	titleedited=true;
@@ -369,10 +376,15 @@
     	subtitleedited=true;
     	$('#articlesubtitle').css("color", "darkred");
     	$('#subtitle.charsremaining').html(200 - $('#articlesubtitle').html().length);
-    	  if((200 - $('#articlesubtitle').html().length) < 25){
-    		$('#subtitle.charsremaining').css("color", "#E3170D");
+    	if ($('#articlesubtitle').html().length>200) {
+    		$("button#savearticle").attr("disabled", "disabled");
+    		$("#articlesubtitle").addClass("toolongwarning");
+    	} else if((200 - $('#articlesubtitle').html().length) < 25) {
+    		$("#articlesubtitle").removeClass("toolongwarning");
+    		$("button#savearticle").removeAttr("disabled");
+    		$('#subtitle.charsremaining').addClass("lowchars");
     	} else {
-    		$('#subtitle.charsremaining').css("color", "green");
+    		$('#subtitle.charsremaining').removeClass("lowchars");
     	}
     });
     $('#articlesubtitle').bind('paste', function() {

--- a/css/orient.css
+++ b/css/orient.css
@@ -1420,10 +1420,19 @@ article header, .authorheader {
 	padding:0 5px;
 	background-color:#fff;
 	z-index:99;
+	color:green;
 }
 
 #subtitle.charsremaining {
 	top:-55px;
+}
+
+.lowchars {
+	color:#E3170D;
+}
+
+.toolongwarning {
+	border:2px solid red;
 }
 
 /* NEXT/PREV IN SERIES */


### PR DESCRIPTION
Together with a database schema change, fixes #40. Displays characters remaining on article title and subtitle fields, displays a warning if that number is below 25, and displays an even more aggressive warning and prevents saving if that number is below 0. 
